### PR TITLE
fix: clean up conflicting imports

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,5 +1,8 @@
-import React, { useEffect, useMemo, useState } from "react";
-import {
+import { quoteCSV } from "./csv.js";
+
+// usar as libs globais (sem import)
+const { useEffect, useMemo, useState } = React;
+const {
   LineChart,
   Line,
   XAxis,
@@ -7,18 +10,15 @@ import {
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
-  // usar as libs globais (sem import)
-const { useEffect, useMemo, useState } = React;
-const { createRoot } = ReactDOM;
-const {
-  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
-  BarChart, Bar, Legend, PieChart, Pie, Cell, RadialBarChart, RadialBar
-} = Recharts;
-
+  BarChart,
+  Bar,
+  Legend,
+  PieChart,
+  Pie,
+  Cell,
   RadialBarChart,
-  RadialBar
-} from "recharts";
-import { quoteCSV } from "./csv.js";
+  RadialBar,
+} = Recharts;
 
 /**
  * PCA UFR – Painel moderno (single-file React)


### PR DESCRIPTION
## Summary
- use globally provided React and Recharts objects instead of conflicting imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2424da94832e9ac0536e9ed93d80