### PR TITLE
Fix GitHub Pages blank screen by using ReactDOM.render

### DIFF
--- a/app.js
+++ b/app.js
@@ -27002,9 +27002,7 @@ Take a look at the reducer(s) handling this action type: ${action.type}.
     a2.remove();
     URL.revokeObjectURL(url);
   }
-  import_react_dom.default
-    .createRoot(document.getElementById("root"))
-    .render(/* @__PURE__ */ import_react58.default.createElement(App));
+  ReactDOM.render(/* @__PURE__ */ import_react58.default.createElement(App), document.getElementById("root"));
 })();
 /*! Bundled license information:
 


### PR DESCRIPTION
## Summary
- use `ReactDOM.render` instead of `createRoot` so bundled app works with the ReactDOM version on GitHub Pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb294ce6b0832e8dc5e42650caeba0